### PR TITLE
Use initial_node_count variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -89,7 +89,7 @@ resource "google_container_cluster" "primary" {
   network            = "${module.network.network_self_link}"
   subnetwork         = "${module.network.subnet_self_link}"
   min_master_version = "${data.google_container_engine_versions.on-prem.latest_master_version}"
-  initial_node_count = 3
+  initial_node_count = "${var.initial_node_count}"
 
   lifecycle {
     ignore_changes = ["ip_allocation_policy.0.services_secondary_range_name"]
@@ -162,4 +162,3 @@ resource "google_container_cluster" "primary" {
     }
   }
 }
-

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,7 +65,7 @@ variable "cluster_name" {
 variable "initial_node_count" {
   description = "The number of nodes initially provisioned in the cluster"
   type        = "string"
-  default     = "3"
+  default     = "1"
 }
 
 variable "ip_range" {


### PR DESCRIPTION
This makes use of the unused `initial_node_count` variable.