### PR TITLE
Remove unused tags variable from network module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,7 +29,6 @@ module "network" {
   project  = "${var.project}"
   region   = "${var.region}"
   vpc_name = "kube-net"
-  tags     = "${var.bastion_tags}"
 }
 
 module "firewall" {
@@ -162,4 +161,3 @@ resource "google_container_cluster" "primary" {
     }
   }
 }
-

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -33,10 +33,6 @@ variable "secondary_ip_range" {
   default = "10.0.92.0/22"
 }
 
-variable "tags" {
-  type = "list"
-}
-
 variable "vpc_name" {
   type    = "string"
   default = "kube-net"


### PR DESCRIPTION
It appears the `tags` variable was added to the network module in error. Additionally, it's not possible to add tags to a network or subnet.