### PR TITLE
Increase node pool size to 2 to support the demo workflow

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,7 +55,6 @@ variable "bastion_machine_type" {
   type        = "string"
   default     = "f1-micro"
 }
-
 variable "bastion_tags" {
   description = "A list of tags applied to your bastion instance."
   type        = "list"
@@ -71,7 +70,7 @@ variable "cluster_name" {
 variable "initial_node_count" {
   description = "The number of nodes initially provisioned in the cluster"
   type        = "string"
-  default     = "1"
+  default     = "2"
 }
 
 variable "ip_range" {


### PR DESCRIPTION
This addresses issue https://github.com/GoogleCloudPlatform/gke-rbac-demo/issues/22

The pod  `pod-labeler` fails to error out because of the issue of failing to establish a connection to the API endpoint. Since the API is not reachable, the subsequent demonstration of RBAC error cannot be made.  

It has been noticed that when the error occurs, similar messages are displayed in the DNS logs.  Attempting to kill and restart the DNS leads to insufficient CPU error.  

Adding a node to the cluster resolves the problem of insufficient CPU, it has been verified that the error flow as documented in the README file is functional after adding the node. 