### PR TITLE
Remove the word 'bastion' from the terraform instance module

### DIFF
--- a/terraform/modules/instance/outputs.tf
+++ b/terraform/modules/instance/outputs.tf
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The public IP of the bastion instance
+// The public IP of the instance
 output "external_ip" {
   value = "${google_compute_instance.instance.network_interface.0.access_config.0.assigned_nat_ip}"
 }


### PR DESCRIPTION
If I believe correctly, this is an abstract module, used for both `bastion` and other nodes. So the label 'bastion' is not technically correct here, right? 

Half opening this PR to ask this question.