### PR TITLE
Added the enable_private_endpoint in main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,6 +130,7 @@ resource "google_container_cluster" "primary" {
   private_cluster_config {
     enable_private_nodes   = true
     master_ipv4_cidr_block = "10.0.90.0/28"
+    enable_private_endpoint= true
   }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,7 +130,7 @@ resource "google_container_cluster" "primary" {
   private_cluster_config {
     enable_private_nodes   = true
     master_ipv4_cidr_block = "10.0.90.0/28"
-    enable_private_endpoint= true
+    enable_private_endpoint= false
   }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible


### PR DESCRIPTION
Added the enable_private_endpoint = true in terraform/main.tf to resolve the following issue:
Error: Missing required argument

  on main.tf line 130, in resource "google_container_cluster" "primary":
 130:   private_cluster_config {

The argument "enable_private_endpoint" is required, but no definition was
found.